### PR TITLE
Couple of length checking fixes

### DIFF
--- a/app/code/community/Netzarbeiter/NicerImageNames/Model/Image.php
+++ b/app/code/community/Netzarbeiter/NicerImageNames/Model/Image.php
@@ -108,7 +108,6 @@ class Netzarbeiter_NicerImageNames_Model_Image extends Mage_Catalog_Model_Produc
                 // The proper thing to do is to not use Windows for hosting,
                 // or, not use attributes with looog values in the name template.
                 
-                list($pathExt, $extension) = $this->_getFileNameParts($file);
                 $pathExt = substr($path . rtrim($pathExt, '/\\') . $pathExt, 0, ($maxlen - strlen($extension) - 2 ));
                 $this->_newFile = rtrim($pathExt, '/\\') . '.' . $extension;
             }


### PR DESCRIPTION
875566d fixes _getFileNameParts expecting just the file and extension (`/oldname/new-file-name.extension`) and not the full path.
bbbcd7e checks filename length which should be 255 characters for most file systems (shame there isn't a `PHP_MAXFILELENGTH`)

I have tested this on Linux and Windows. Feel free to refactor as I can see the `setBaseFile` function getting a bit messy. Would be willing to help out with some unit tests.
